### PR TITLE
Minors grammatical rewordings

### DIFF
--- a/manual/manual/cmds/intf-c.etex
+++ b/manual/manual/cmds/intf-c.etex
@@ -986,18 +986,20 @@ Use the normal C array syntax instead.
 with the garbage collector using the "caml_register_global_root" function.
 \end{gcrule}
 
-The one may need to access values in OCaml heap from external code, for
-example when main loop of the program is implemented in C++. In this case the
-value of type "value" can be stored outside the OCaml heap for later use. In this
-subsection these external locations will be called \emph{global} values.
+One may need to access values in OCaml heap from external code, for
+example when the main loop of the program is implemented in C++. In this
+case, values of type "value" can be stored outside the OCaml heap for later
+use. In this subsection, these external locations are called \emph{global}
+values.
 
-Saving an OCaml value outside OCaml heap in a global value will work
-well when a piece of data is an unboxed integer and may work well when the it is a pointer
-outside OCaml heap. However, if a piece of data is a \emph{pointer to the OCaml heap} the
-one needs to register another location of this data in the OCaml runtime.
+Saving an OCaml value outside OCaml heap in a global value works
+well when a piece of data is an unboxed integer and may work well when
+it is a pointer outside OCaml heap. However, if a piece of data is a
+\emph{pointer to the OCaml heap} then one needs to register the location of
+this data in the OCaml runtime.
 Registration of a global value "v" of type "value" is achieved by calling
 "caml_register_global_root(&v)" just before or just after a valid
-value is stored in "v" for the first time. No any of the OCaml runtime functions
+value is stored in "v" for the first time: none of the OCaml runtime functions
 or macros should be called between registering and storing the value.
 
 A registered global value "v" can be un-registered by calling
@@ -1005,25 +1007,25 @@ A registered global value "v" can be un-registered by calling
 
 The importance of registering global values consists of two aspects. The first
 is that data being registered may be sweeped by OCaml garbage collector. In that
-case it should be explicitly explained
-to the GC that this data should be \emph{alive} as far as program runs
-(or until it will be unregistered using the function above),
-i.e. this value should be a \emph{root} in the graph of references between
-all OCaml values.
+case it should be explicitly explained to the GC that this data should be
+\emph{alive} as long as the program runs (or until it will be unregistered
+using the function above), i.e. this value should be a \emph{root} in
+the graph of references between all OCaml values.
 
-The second aspect is related to a number of heaps in the OCaml runtime. There are
-two generations: the minor heaps for ``young'' values and the major one
-for ``old'' ones. When a ``young'' value becomes old enough it is promoted to the
-major heap and moved from old memory address to another one. If this
-value was registered as a global root the OCaml runtime should
-guarantee that global value still points to the right
-data (holds new pointer). This issue is resolved by the function "caml_register_global_root" which
-has the signature "void caml_register_global_root(value*)". It takes a
-pointer to a global value and when OCaml value is promoted to the major heap
-the runtime updates global value with new correct OCaml pointer.
+The second aspect is related to the dual heaps used by the OCaml runtime.
+There are two generations: the minor heaps for ``young'' values and the
+major one for ``old'' ones. When a ``young'' value becomes old enough it
+is promoted to the major heap and moved from its old memory address to
+another one. If this value was registered as a global root the OCaml
+runtime should guarantee that the global value still points to the right
+data (holds the new pointer). This issue is resolved by the function
+"caml_register_global_root" which has the signature
+"void caml_register_global_root(value*)". It takes a pointer to a global
+value and when the OCaml value is promoted to the major heap, the runtime
+updates the global value with the new correct OCaml pointer.
 
 If the contents of the global variable "v" are seldom modified after
-registration, better performance can be achieved by calling
+registration, better performances can be achieved by calling
 "caml_register_generational_global_root(&v)" to register "v" (after
 its initialization with a valid "value", but before any allocation or
 call to the GC functions),


### PR DESCRIPTION
This small PR implements a few of the copy-editing that  I made before on your OCaml compiler's PR detailling the use of `caml_register_global_root`. Please feel free to reword it as you like, but I think fixing these minor details will make the rest of the review more straightforward. 